### PR TITLE
Feature | Add option to search inside selected playlist

### DIFF
--- a/services/playlists.go
+++ b/services/playlists.go
@@ -66,8 +66,9 @@ type PlaylistsErrorMsg struct {
 
 type PlaylistsMsg string
 type SearchResultsMsg struct {
-	Results     []table.Row
-	TextResults []textTable.Row
+	PlaylistName string
+	Results      []table.Row
+	TextResults  []textTable.Row
 }
 
 func GetPlaylists() tea.Msg {
@@ -152,7 +153,7 @@ func SearchInPlaylist(playlistId string, searchTerm string) tea.Msg {
 
 	results, textResults, _ := getTracksAndSearch(playlist, strings.ToLower(searchTerm))
 
-	return SearchResultsMsg{results, textResults}
+	return SearchResultsMsg{playlist.Name, results, textResults}
 }
 
 func getPlaylistWithOffset(id string, playlist *playlist) error {

--- a/tui/list.go
+++ b/tui/list.go
@@ -68,7 +68,14 @@ func (model *PlaylistsModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return model, tea.Quit
 		}
 
-		model.results = CreateTable("PLAYLISTS", playlists, textPlaylists, false, "")
+		model.results = CreateTable(
+			utils.PlaylistsTable,
+			playlists,
+			textPlaylists,
+			false,
+			"",
+			tableContext{},
+		)
 
 		return model.results.Update(msg)
 	case services.PlaylistsErrorMsg:


### PR DESCRIPTION
- Added new text over the search results table to indicate what is the selected playlist (i.e. "Selected playlist: SELECTED_PLAYLIST_NAME")
  - Updated the `search.go` file to add the text when creating a new `TableModel`.
  - Refactored the `View` method on the `table.go` file to be more readable.
    - The conditions for displaying the help options were wrong. I fixed it so the condition could include the songs table as well.
  - Updated the `playlists.go` file to add a new attribute to `SearchResultsMsg` struct so we can have the playlist name available for display.
- Added new option for the user to be able to do a new search in the current selected playlist.
  - Updated the `table.go` file to:
    - Add the new option.
    - Add new atribute to `TableModel` struct so we can pass the selected playlist ID to the table. That is needed because we need to pass that ID to the new SearchModel we are creating when user selects the new option.