### PR TITLE
Feature | Add continuous flow through table rows

### DIFF
--- a/tui/table.go
+++ b/tui/table.go
@@ -155,6 +155,18 @@ func (model TableModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 				return searchModel.Update(msg)
 			}
+		case "up":
+			if model.table.Cursor() == 0 {
+				model.table.GotoBottom()
+
+				return model, nil
+			}
+		case "down":
+			if model.table.Cursor() == len(model.table.Rows())-1 {
+				model.table.GotoTop()
+
+				return model, nil
+			}
 		}
 		switch {
 		case key.Matches(msg, tableKeys.newSearch):


### PR DESCRIPTION
Added new cases when moving through the table rows. If you press the "up" key and you are in the first row, you will move to the last row. If you press the "down" key while being in the last row, you will move to the first row. This will give the impression of a continuous flow between rows.